### PR TITLE
Fixes 'cache' directive in mailers not working in Rails 4.2

### DIFF
--- a/lib/mailer_fragment_caching.rb
+++ b/lib/mailer_fragment_caching.rb
@@ -14,4 +14,28 @@ module MailerFragmentCaching
     perform_caching && cache_store
   end
 
+  # In Rails4, <tt>ActionController::Caching#view_cache_dependencies</tt> must
+  # also be duplicated in order for +cache+ to work.
+  # <tt>ActionView::Helpers::CacheHelper#fragment_name_with_digest</tt> relies on it.
+  if Rails::VERSION::MAJOR >= 4
+    def self.included(base)
+      base.class_eval do
+        class_attribute :_view_cache_dependencies
+        self._view_cache_dependencies = []
+        helper_method :view_cache_dependencies if respond_to?(:helper_method)
+      end
+    end
+
+    def self.view_cache_dependency(&dependency)
+      self._view_cache_dependencies += [dependency]
+    end
+
+    def view_cache_dependencies
+      self.class._view_cache_dependencies.map { |dep| instance_exec(&dep) }.compact
+    end
+
+    def instrument_fragment_cache(name, key) # :nodoc:
+      yield if block_given?
+    end
+  end
 end


### PR DESCRIPTION
Closes #3.  Allows both Rails 3 and Rails 4 to use the `<% cache ... do %>` direction in mailer view templates.

Note: tested in Rails 3.2.22.2 and Rails 4.2.7, however I didn't test any earlier versions of Rails4
